### PR TITLE
feat: add paginated cards

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -19,7 +19,8 @@
     "bs-css",
     "reason-relay",
     "reason-promise",
-    "bs-fetch"
+    "bs-fetch",
+    "bs-webapi"
   ],
   "ppx-flags": ["reason-relay/ppx"],
   "refmt": 3

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -20,7 +20,8 @@
     "reason-relay",
     "reason-promise",
     "bs-fetch",
-    "bs-webapi"
+    "bs-webapi",
+    "re-debouncer"
   ],
   "ppx-flags": ["reason-relay/ppx"],
   "refmt": 3

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bs-fetch": "^0.6.1",
     "bs-webapi": "^0.15.9",
     "graphql": "^15.1.0",
+    "re-debouncer": "^2.1.0",
     "react": "0.0.0-experimental-f6b8d31a7",
     "react-dom": "0.0.0-experimental-f6b8d31a7",
     "react-relay": "0.0.0-experimental-8cc94ddc",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "bs-css": "^10.0.1",
     "bs-fetch": "^0.6.1",
+    "bs-webapi": "^0.15.9",
     "graphql": "^15.1.0",
     "react": "0.0.0-experimental-f6b8d31a7",
     "react-dom": "0.0.0-experimental-f6b8d31a7",
@@ -37,8 +38,8 @@
   },
   "devDependencies": {
     "bs-platform": "^7.3.2",
-    "moduleserve": "^0.9.0",
     "html-webpack-plugin": "^3.2.0",
+    "moduleserve": "^0.9.0",
     "webpack": "^4.0.1",
     "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.8"

--- a/src/App.re
+++ b/src/App.re
@@ -2,10 +2,10 @@ open Css;
 
 module Query = [%relay.query
   {|
-    query AppQuery {
-      __typename
-    }
-  |}
+  query AppQuery {
+    ...Cards_query
+  }
+|}
 ];
 
 let baseStyle =
@@ -18,19 +18,17 @@ let baseStyle =
 
 [@react.component]
 let make = () => {
-    let url = ReasonReactRouter.useUrl();
+  let url = ReasonReactRouter.useUrl();
+
+  let query = Query.use(~variables=(), ());
 
   let page =
     switch(url.path){
-    | [] => <Home />
+    | [] => <Home query={query.getFragmentRefs()} />
     | ["login"] => <div>{"Login" |> ReasonReact.string}</div>
     | _ => <div>{"Page not found" |> ReasonReact.string}</div>
     };
-
-  let loading = <Loading />;
     <div className=baseStyle>
-      <ReactExperimental.Suspense fallback=loading>
         page
-      </ReactExperimental.Suspense>
     </div>
 }

--- a/src/Index.re
+++ b/src/Index.re
@@ -1,7 +1,12 @@
+
+  let loading = <Loading />;
+
 // ReactDOMRe.renderToElementWithId(<App />, "root");
   ReactExperimental.renderConcurrentRootAtElementWithId(
     <ReasonRelay.Context.Provider environment=RelayEnv.environment>
-      <App />
+      <ReactExperimental.Suspense fallback=loading>
+        <App />
+      </ReactExperimental.Suspense>
     </ReasonRelay.Context.Provider>,
     "root",
   );

--- a/src/__generated__/CardsRefetchQuery_graphql.re
+++ b/src/__generated__/CardsRefetchQuery_graphql.re
@@ -5,7 +5,18 @@ module Types = {
     getFragmentRefs:
       unit => {. "__$fragment_ref__Cards_query": Cards_query_graphql.t},
   };
-  type variables = unit;
+  type refetchVariables = {
+    count: option(int),
+    cursor: option(string),
+  };
+  let makeRefetchVariables = (~count=?, ~cursor=?, ()): refetchVariables => {
+    count,
+    cursor,
+  };
+  type variables = {
+    count: int,
+    cursor: string,
+  };
 };
 
 module Internal = {
@@ -37,7 +48,10 @@ module Internal = {
 
 type preloadToken;
 
-module Utils = {};
+module Utils = {
+  open Types;
+  let makeVariables = (~count, ~cursor): variables => {count, cursor};
+};
 
 type operationType = ReasonRelay.queryNode;
 
@@ -45,43 +59,68 @@ let node: operationType = [%raw
   {json| (function(){
 var v0 = [
   {
-    "kind": "Literal",
-    "name": "after",
-    "value": ""
+    "kind": "LocalArgument",
+    "name": "count",
+    "type": "Int!",
+    "defaultValue": 40
   },
   {
-    "kind": "Literal",
+    "kind": "LocalArgument",
+    "name": "cursor",
+    "type": "String!",
+    "defaultValue": ""
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
     "name": "first",
-    "value": 40
+    "variableName": "count"
   }
 ];
 return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "AppQuery",
+    "name": "CardsRefetchQuery",
     "type": "Query",
     "metadata": null,
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "selections": [
       {
         "kind": "FragmentSpread",
         "name": "Cards_query",
-        "args": null
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "count",
+            "variableName": "count"
+          },
+          {
+            "kind": "Variable",
+            "name": "cursor",
+            "variableName": "cursor"
+          }
+        ]
       }
     ]
   },
   "operation": {
     "kind": "Operation",
-    "name": "AppQuery",
-    "argumentDefinitions": [],
+    "name": "CardsRefetchQuery",
+    "argumentDefinitions": (v0/*: any*/),
     "selections": [
       {
         "kind": "LinkedField",
         "alias": null,
         "name": "cards",
-        "storageKey": "cards(after:\"\",first:40)",
-        "args": (v0/*: any*/),
+        "storageKey": null,
+        "args": (v1/*: any*/),
         "concreteType": "CardConnection",
         "plural": false,
         "selections": [
@@ -166,7 +205,7 @@ return {
         "kind": "LinkedHandle",
         "alias": null,
         "name": "cards",
-        "args": (v0/*: any*/),
+        "args": (v1/*: any*/),
         "handle": "connection",
         "key": "Cards_query_cards",
         "filters": null
@@ -175,10 +214,13 @@ return {
   },
   "params": {
     "operationKind": "query",
-    "name": "AppQuery",
+    "name": "CardsRefetchQuery",
     "id": null,
-    "text": "query AppQuery {\n  ...Cards_query\n}\n\nfragment Cards_query on Query {\n  cards(first: 40, after: \"\") {\n    edges {\n      node {\n        id\n        image\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
-    "metadata": {}
+    "text": "query CardsRefetchQuery(\n  $count: Int! = 40\n  $cursor: String! = \"\"\n) {\n  ...Cards_query_1G22uz\n}\n\nfragment Cards_query_1G22uz on Query {\n  cards(first: $count, after: $cursor) {\n    edges {\n      node {\n        id\n        image\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
+    "metadata": {
+      "derivedFrom": "Cards_query",
+      "isRefetchableQuery": true
+    }
   }
 };
 })() |json}

--- a/src/__generated__/Cards_query_graphql.re
+++ b/src/__generated__/Cards_query_graphql.re
@@ -1,0 +1,189 @@
+/* @generated */
+
+module Types = {
+  type fragment_cards_edges_node = {
+    id: string,
+    image: string,
+  };
+  type fragment_cards_edges = {node: option(fragment_cards_edges_node)};
+  type fragment_cards = {edges: array(option(fragment_cards_edges))};
+
+  type fragment = {cards: fragment_cards};
+};
+
+module Internal = {
+  type fragmentRaw;
+  let fragmentConverter: Js.Dict.t(Js.Dict.t(Js.Dict.t(string))) = [%raw
+    {json| {"__root":{"cards_edges":{"na":""},"cards_edges_node":{"n":""}}} |json}
+  ];
+  let fragmentConverterMap = ();
+  let convertFragment = v =>
+    v
+    ->ReasonRelay._convertObj(
+        fragmentConverter,
+        fragmentConverterMap,
+        Js.undefined,
+      );
+};
+
+type t;
+type fragmentRef;
+type fragmentRefSelector('a) = {.. "__$fragment_ref__Cards_query": t} as 'a;
+external getFragmentRef: fragmentRefSelector('a) => fragmentRef = "%identity";
+
+module Utils = {
+  open Types;
+  let getConnectionNodes_cards:
+    fragment_cards => array(fragment_cards_edges_node) =
+    connection =>
+      connection.edges
+      ->Belt.Array.keepMap(edge =>
+          switch (edge) {
+          | None => None
+          | Some(edge) =>
+            switch (edge.node) {
+            | None => None
+            | Some(node) => Some(node)
+            }
+          }
+        );
+};
+
+type operationType = ReasonRelay.fragmentNode;
+
+let node: operationType = [%raw
+  {json| (function(){
+var v0 = [
+  "cards"
+];
+return {
+  "kind": "Fragment",
+  "name": "Cards_query",
+  "type": "Query",
+  "metadata": {
+    "connection": [
+      {
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "count",
+          "cursor": "cursor"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "operation": require('./CardsRefetchQuery_graphql.bs.js').node,
+      "fragmentPathInResult": []
+    }
+  },
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "count",
+      "type": "Int!",
+      "defaultValue": 40
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "cursor",
+      "type": "String!",
+      "defaultValue": ""
+    }
+  ],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": "cards",
+      "name": "__Cards_query_cards_connection",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "CardConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "CardEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Card",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "image",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__typename",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfoExtended",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "endCursor",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasNextPage",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+})() |json}
+];

--- a/src/__generated__/Cards_query_graphql.re
+++ b/src/__generated__/Cards_query_graphql.re
@@ -5,7 +5,10 @@ module Types = {
     id: string,
     image: string,
   };
-  type fragment_cards_edges = {node: option(fragment_cards_edges_node)};
+  type fragment_cards_edges = {
+    node: option(fragment_cards_edges_node),
+    cursor: string,
+  };
   type fragment_cards = {edges: array(option(fragment_cards_edges))};
 
   type fragment = {cards: fragment_cards};

--- a/src/__generated__/DeprecatedCardsQuery_graphql.re
+++ b/src/__generated__/DeprecatedCardsQuery_graphql.re
@@ -81,7 +81,7 @@ return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "CardsQuery",
+    "name": "DeprecatedCardsQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": [],
@@ -127,7 +127,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "CardsQuery",
+    "name": "DeprecatedCardsQuery",
     "argumentDefinitions": [],
     "selections": [
       {
@@ -178,9 +178,9 @@ return {
   },
   "params": {
     "operationKind": "query",
-    "name": "CardsQuery",
+    "name": "DeprecatedCardsQuery",
     "id": null,
-    "text": "query CardsQuery {\n  cards {\n    edges {\n      node {\n        text\n        name\n        image\n        manaCost\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query DeprecatedCardsQuery {\n  cards {\n    edges {\n      node {\n        text\n        name\n        image\n        manaCost\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/components/Card.re
+++ b/src/components/Card.re
@@ -5,7 +5,7 @@ let make = (~image: option(string)=?) => {
   let cardImg =
     switch(image){
       | None => React.null;
-      | Some(image) => <img src=image alt="card-image" />
+      | Some(image) => <img key=image src=image alt="card-image" />
     };
 /* 
     let cardName =

--- a/src/components/Cards.re
+++ b/src/components/Cards.re
@@ -41,6 +41,7 @@ module CardListFragment = [%relay.fragment
           id
           image
         }
+        cursor
       }
     }
   }
@@ -90,12 +91,12 @@ let make = (~query as queryRef) => {
       <ul className=cardsContainerStyle>
         dataToShow
       </ul>
-      {hasNext ?
+      /* {hasNext ?
         <Button
           text="Load more cards!"
           onClick={_ => loadNext(~count=30, ()) |> ignore} />
         :
         React.null
-      }
+      } */
     </div>
 }

--- a/src/components/Cards.re
+++ b/src/components/Cards.re
@@ -1,20 +1,6 @@
 open Css;
-
-module CardsQuery = [%relay.query{|
-    query CardsQuery {
-      cards {
-        edges {
-          node {
-            text
-            name
-            image
-            manaCost
-          }
-        }
-      }
-    }
-  |}];
-
+// open Utils;
+// open Webapi.Dom;
 
 let cardsContainerStyle =
   merge([
@@ -22,82 +8,112 @@ let cardsContainerStyle =
       display(flexBox),
       flexDirection(row),
       justifyContent(center),
-      width(`percent(120.0)),
       flexWrap(wrap),
       listStyle(`none, `inside, `none),
+      padding(px(0))
     ]),
     "cards-container"
   ]);
 
-[@react.component]
-let make = () => {
-    let queryData = CardsQuery.use(~variables=(), ());
-
-    // let item =
-    //   switch(edge){
-    //     | Some(node) => {ReasonReact.string(node.name)};
-    //     | None => React.null;
-    //   }
-
-    // let parseData = (~edges=?) =>
-    //   switch(edges){
-    //     | None => React.null;
-    //     | Some(edges) =>
-    //       edges->Belt.Array.keepMap(edge =>
-    //         switch (edge) {
-    //           | Some({node: Some(node)}) => Some(node);
-    //           | _ => None;
-    //         }
-    //     )
-    //   }
-  let data =
-    switch(queryData.cards.edges) {
-      | [||] => <div>{ReasonReact.string("Nada")}</div>
-      | edges => 
-        edges -> Belt.Array.keepMap(edge =>
-        switch(edge){
-          | Some({node: Some(node)})  => Some(node);
-          | _ => None;
-          }
-            ) -> Belt.Array.map(item =>
-                <li key=item.name>
-                  <Card image=item.image />
-                </li>
-              ) -> React.array;
-    };
-
-  <ul className=cardsContainerStyle>
-    data
-  </ul>
+  
+  let outsideContainerStyle =
+    merge([
+      style([
+        display(flexBox),
+        flexDirection(column),
+      ]),
+      "outside-container"
+    ]);
     
-    // let elements = (~edges=?) => 
-    //   switch edges {
-    //     | None => React.null;
-    //     | Some(edges) => 
-    //       edges->Belt.Array.map(edge => {
-    //         switch(edge) {
-    //           | None => React.null;
-    //           | Some(edge) =>
-    //             switch(edge) {
-    //               | Some(node) => <div>{ReasonReact.string("node")}</div>
-    //               | None => <div>{ReasonReact.string("no node")}</div>
-    //             };
-    //           }
-    //       })->React.array
-    //   };
 
-    // switch(queryData.cards.edges) {
-    //   | [||] => <div>{ReasonReact.string("Nada")}</div>
-    //   | edges => elements(~edges=edges)
-    // }
+
+module CardListFragment = [%relay.fragment
+  {|
+  fragment Cards_query on Query
+    @refetchable(queryName: "CardsRefetchQuery")
+    @argumentDefinitions(
+      count: { type: "Int!", defaultValue: 40 }
+      cursor: { type: "String!", defaultValue: "" }
+    ) {
+    cards(first: $count, after: $cursor) @connection(key: "Cards_query_cards") {
+      edges {
+        node {
+          id
+          image
+        }
+      }
+    }
+  }
+  |}
+];
+
+// type action =
+//   | Update;
+
+// type state = {
+//   currentHeight: int
+// };
+
+
+[@react.component]
+let make = (~query as queryRef) => {
+
+  // let (state, dispatch) = 
+  //   React.useReducer((state, action) =>
+  //     switch (action) {
+  //       | Update => {currentHeight: state.currentHeight +1800}
+  //     },
+  //     {currentHeight: 1800},
+  //   );
+
+    
+  //let cardList = CardListFragment.use(queryRef);
+  let ReasonRelay.{data, hasNext, isLoadingNext, loadNext} = CardListFragment.usePagination(queryRef);
+  let cardList = data.cards->CardListFragment.getConnectionNodes_cards;
+  // let (height, setHeight) = React.useState(_ => -1000);
+  // let pageBottom = (e) => bottomDistance (e) >= state.currentHeight;
+  // let handleScroll = (e) => {
+  //   dispatch(Update);
+  //   let x = bottomDistance(e);
+  //   Js.log("ScrollY atual")
+  //   Js.log(x);
+  //   Js.log("currentHeight atual");
+  //   Js.log(state.currentHeight);
+  //   if(pageBottom(e) && !isLoadingNext && hasNext){
+  //     // Js.log("Under height");
+  //     // Js.log("height atual")
+  //     // Js.log(state.currentHeight)
+  //     loadNext(~count=30, ()) |> ignore;
+  //   };
+  
+  // }
+  // let bindEvent = () =>
+  //   Document.addEventListener("scroll", handleScroll, document);
+
+  // React.useEffect0(() => {
+  //   bindEvent();
+
+  //   Some(() => Js.log("Failed binding scroll listener"));
+  // })
+
+
+  let dataToShow =
+    {cardList
+      -> Belt.Array.map(card => 
+        <Card image=card.image />)
+          } -> React.array;
+
+
+    <div className=outsideContainerStyle>
+      <ul className=cardsContainerStyle>
+        dataToShow
+      </ul>
+      {hasNext ?
+        <Button
+          text="Load more cards!"
+          onClick={_ => loadNext(~count=30, ()) |> ignore} />
+        :
+        React.null
+      }
+    </div>
 }
-
-
-          // {
-          //   edges
-          //   ->Belt.Array.map(node =>
-          //       <li key={node.name}> {React.string(node.text)} </li>
-          //     )
-          //   /* Since everything is typed, the arrays need to be, too! */
-          //   ->React.array
-          // }

--- a/src/components/Cards.re
+++ b/src/components/Cards.re
@@ -1,6 +1,6 @@
 open Css;
-// open Utils;
-// open Webapi.Dom;
+open Utils;
+open Webapi.Dom;
 
 let cardsContainerStyle =
   merge([
@@ -10,7 +10,7 @@ let cardsContainerStyle =
       justifyContent(center),
       flexWrap(wrap),
       listStyle(`none, `inside, `none),
-      padding(px(0))
+      padding(px(0)),
     ]),
     "cards-container"
   ]);
@@ -47,54 +47,36 @@ module CardListFragment = [%relay.fragment
   |}
 ];
 
-// type action =
-//   | Update;
+ type action =
+   | Update;
 
-// type state = {
-//   currentHeight: int
-// };
+ type state = {
+   currentHeight: int
+ };
 
 
 [@react.component]
 let make = (~query as queryRef) => {
-
-  // let (state, dispatch) = 
-  //   React.useReducer((state, action) =>
-  //     switch (action) {
-  //       | Update => {currentHeight: state.currentHeight +1800}
-  //     },
-  //     {currentHeight: 1800},
-  //   );
-
-    
-  //let cardList = CardListFragment.use(queryRef);
   let ReasonRelay.{data, hasNext, isLoadingNext, loadNext} = CardListFragment.usePagination(queryRef);
   let cardList = data.cards->CardListFragment.getConnectionNodes_cards;
   // let (height, setHeight) = React.useState(_ => -1000);
-  // let pageBottom = (e) => bottomDistance (e) >= state.currentHeight;
-  // let handleScroll = (e) => {
-  //   dispatch(Update);
-  //   let x = bottomDistance(e);
-  //   Js.log("ScrollY atual")
-  //   Js.log(x);
-  //   Js.log("currentHeight atual");
-  //   Js.log(state.currentHeight);
-  //   if(pageBottom(e) && !isLoadingNext && hasNext){
-  //     // Js.log("Under height");
-  //     // Js.log("height atual")
-  //     // Js.log(state.currentHeight)
-  //     loadNext(~count=30, ()) |> ignore;
-  //   };
-  
-  // }
-  // let bindEvent = () =>
-  //   Document.addEventListener("scroll", handleScroll, document);
+  let pageBottom = (e) => scroller(e);
+  let handleScroll = (e) => {
+     if(pageBottom(e) && !isLoadingNext && hasNext){
+       loadNext(~count=15, ()) |> ignore;
+     }
+   }
 
-  // React.useEffect0(() => {
-  //   bindEvent();
+   let debounceScroll = Debouncer.make(~wait=5000, handleScroll);
 
-  //   Some(() => Js.log("Failed binding scroll listener"));
-  // })
+   let bindEvent = () =>
+     Document.addEventListener("scroll", debounceScroll, document);
+
+   React.useEffect0(() => {
+     bindEvent();
+
+     Some(() => Js.log("Failed binding scroll listener"));
+   })
 
 
   let dataToShow =

--- a/src/components/Deprecated_Cards.re
+++ b/src/components/Deprecated_Cards.re
@@ -1,7 +1,7 @@
 open Css;
 
 module CardsQuery = [%relay.query{|
-    query CardsQuery {
+    query DeprecatedCardsQuery {
       cards {
         edges {
           node {

--- a/src/components/Deprecated_Cards.re
+++ b/src/components/Deprecated_Cards.re
@@ -1,0 +1,54 @@
+open Css;
+
+module CardsQuery = [%relay.query{|
+    query CardsQuery {
+      cards {
+        edges {
+          node {
+            text
+            name
+            image
+            manaCost
+          }
+        }
+      }
+    }
+  |}];
+
+
+let cardsContainerStyle =
+  merge([
+    style([
+      display(flexBox),
+      flexDirection(row),
+      justifyContent(center),
+      width(`percent(120.0)),
+      flexWrap(wrap),
+      listStyle(`none, `inside, `none),
+    ]),
+    "cards-container"
+  ]);
+
+[@react.component]
+let make = () => {
+  let queryData = CardsQuery.use(~variables=(), ());
+  let data =
+    switch(queryData.cards.edges) {
+      | [||] => <div>{ReasonReact.string("Nada")}</div>
+      | edges => 
+        edges -> Belt.Array.keepMap(edge =>
+        switch(edge){
+          | Some({node: Some(node)})  => Some(node);
+          | _ => None;
+          }
+            ) -> Belt.Array.map(item =>
+                <li key=item.name>
+                  <Card image=item.image />
+                </li>
+              ) -> React.array;
+    };
+
+  <ul className=cardsContainerStyle>
+    data
+  </ul>
+}

--- a/src/components/Home.re
+++ b/src/components/Home.re
@@ -1,6 +1,6 @@
 [@react.component]
-let make = () =>
+let make = (~query) =>
   <Container>
     <Section />
-    <Cards />
+    <Cards query=query />
   </Container>

--- a/src/components/layout/Button.re
+++ b/src/components/layout/Button.re
@@ -21,7 +21,8 @@ let centerButtonStyle = (isHovering: bool) => {
       borderWidth(px(0)),
       height(px(48)),
       padding(px(8)),
-      width(px(240))
+      width(px(240)),
+      cursor(`pointer)
     ]),
     "center-button"
   ]);

--- a/src/components/layout/Button.re
+++ b/src/components/layout/Button.re
@@ -1,0 +1,48 @@
+open Css;
+
+let textColor = (isHovering: bool) => isHovering ? hex("fcba03") : hex("fff");
+
+type state = {isHovering: bool};
+type action =
+  | ToggleHover;
+
+
+let centerButtonStyle = (isHovering: bool) => {
+  let usedColor = textColor(isHovering);
+
+  merge([
+    style([
+      alignSelf(center),
+      background(hex("333")),
+      color(usedColor),
+      borderRadius(px(4)),
+      marginTop(`percent(4.)),
+      marginBottom(`percent(20.)),
+      borderWidth(px(0)),
+      height(px(48)),
+      padding(px(8)),
+      width(px(240))
+    ]),
+    "center-button"
+  ]);
+};
+
+
+
+[@react.component]
+let make = (~text: string, ~onClick) => {
+  let (state, dispatch) =
+  React.useReducer(
+    (state, action) =>
+      switch (action) {
+        | ToggleHover => {isHovering: !state.isHovering}
+      },
+    {isHovering: false},
+  );
+  <button
+    onMouseOver={_event => dispatch(ToggleHover)}
+    onMouseOut={_event => dispatch(ToggleHover)} 
+    className=centerButtonStyle(state.isHovering)
+    onClick={_ => onClick()}>{ReasonReact.string(text)}
+  </button>
+}

--- a/src/components/layout/Container.re
+++ b/src/components/layout/Container.re
@@ -4,10 +4,9 @@ let containerStyle =
   merge([
     style([
       display(flexBox),
-      paddingLeft(`percent(20.)),
-      paddingRight(`percent(20.)),
+      paddingLeft(`percent(15.)),
+      paddingRight(`percent(15.)),
       flexDirection(column),
-      alignItems(center),
     ]),
     "container"
   ]);

--- a/src/components/layout/Container.re
+++ b/src/components/layout/Container.re
@@ -7,6 +7,7 @@ let containerStyle =
       paddingLeft(`percent(15.)),
       paddingRight(`percent(15.)),
       flexDirection(column),
+      height(`percent(100.))
     ]),
     "container"
   ]);

--- a/src/util/Utils.re
+++ b/src/util/Utils.re
@@ -1,3 +1,5 @@
 [@bs.module "../util/utilities"] external bottomDistance : Dom.event => int = "distanceFromBottom";
 
+[@bs.module "../util/utilities"] external scroller: Dom.event => bool = "scroller";
+
 [@bs.val] external setTimeout : (unit => unit, int) => float = "setTimeout";

--- a/src/util/Utils.re
+++ b/src/util/Utils.re
@@ -1,0 +1,3 @@
+[@bs.module "../util/utilities"] external bottomDistance : Dom.event => int = "distanceFromBottom";
+
+[@bs.val] external setTimeout : (unit => unit, int) => float = "setTimeout";

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -3,8 +3,16 @@ module.exports = {
     // console.log("position atual", Math.floor(
     //   document.body.clientHeight - (window.scrollY + window.innerHeight)
     // ));
+    console.log('scrolling', Math.floor(window.scrollY))
     return Math.floor(
       window.scrollY
     );
   },
+  scroller: function() {
+    if((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
+      console.log('page bottom');
+      return true;
+    }
+    return false;
+  }
 };

--- a/src/util/utilities.js
+++ b/src/util/utilities.js
@@ -1,0 +1,10 @@
+module.exports = {
+  distanceFromBottom: function() {
+    // console.log("position atual", Math.floor(
+    //   document.body.clientHeight - (window.scrollY + window.innerHeight)
+    // ));
+    return Math.floor(
+      window.scrollY
+    );
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,6 +1156,11 @@ bs-platform@^7.3.2:
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.3.2.tgz#301f5c9b4e8cf5713cb60ca22e145e56e793affe"
   integrity sha512-seJL5g4anK9la4erv+B2o2sMHQCxDF6OCRl9en3hbaUos/S3JsusQ0sPp4ORsbx5eXfHLYBwPljwKXlgpXtsgQ==
 
+bs-webapi@^0.15.9:
+  version "0.15.9"
+  resolved "https://registry.yarnpkg.com/bs-webapi/-/bs-webapi-0.15.9.tgz#d1dcfbd40499a3b0914daacc4ceef47a0f3c906f"
+  integrity sha512-bmzO6na2HmK01a34qB7afMwfVSrPxkP3EGzUslWObuxbHIlLC0PAMDu4lA8ZL5NasBUctlwnA1QZxox+1aNWWw==
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4045,6 +4045,11 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+re-debouncer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/re-debouncer/-/re-debouncer-2.1.0.tgz#2eaf7994ba41590f4f80d4a363ae8905156b7dc1"
+  integrity sha512-Iy9BecWF9X4V6zXfL3ROZpKGkCnpzYdjG/j6NIBxQn7gEwO2DzED5BsbfRUiPeqr7C0tAD0HPHF6tYIcQFEnyA==
+
 react-dom@0.0.0-experimental-33c3af284:
   version "0.0.0-experimental-33c3af284"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-33c3af284.tgz#d4acd21209a299832d9233ceafc25a6fe1b1d076"


### PR DESCRIPTION
- [x] Add paginated component to fetch cards
- [ ] Use window scroll to paginate cards

Currently unable to use window scroll to paginate cards because I'm not able to set a safe window height to prevent the `loadNext()`  function from running a thousand times. Probably debouncing using lodash can fix this.